### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/undecidables/Requirements-Documentation.png?label=ready&title=Ready)](https://waffle.io/undecidables/Requirements-Documentation)
 # Requirements-Documentation
 This repo contains the documentation regarding functional and non-functinal requirments of the project.
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/undecidables/Requirements-Documentation

This was requested by a real person (user VivianLVenter) on waffle.io, we're not trying to spam you.
